### PR TITLE
Add WebRTC demo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # kevvn.github.io
+
+This repository hosts a small demo for experimenting with WebRTC connections.
+
+## WebRTC demo
+
+1. Open `index.html` in two browsers.
+2. Click **Start Camera** on both to enable video and audio.
+3. On one browser click **Create Offer** and copy the generated text.
+4. Paste the offer into the other browser's **Offer** field and click **Create Answer**.
+5. Copy the answer back to the first browser's **Answer** field and click **Apply Answer**.
+
+After the exchange finishes a peer-to-peer connection will be established and the remote video will be displayed.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WebRTC Demo</title>
+  <style>
+    video {
+      width: 45%;
+    }
+    textarea {
+      width: 90%;
+      height: 6rem;
+    }
+  </style>
+</head>
+<body>
+  <h1>WebRTC Communication Demo</h1>
+  <div>
+    <video id="localVideo" autoplay playsinline muted></video>
+    <video id="remoteVideo" autoplay playsinline></video>
+  </div>
+  <div>
+    <button id="startBtn">Start Camera</button>
+    <button id="createOfferBtn" disabled>Create Offer</button>
+    <button id="createAnswerBtn">Create Answer</button>
+    <button id="applyAnswerBtn">Apply Answer</button>
+  </div>
+  <div>
+    <h2>Offer</h2>
+    <textarea id="offer" placeholder="Local offer will appear here"></textarea>
+  </div>
+  <div>
+    <h2>Answer</h2>
+    <textarea id="answer" placeholder="Paste remote answer here"></textarea>
+  </div>
+  <script src="webrtc.js"></script>
+</body>
+</html>

--- a/webrtc.js
+++ b/webrtc.js
@@ -1,0 +1,63 @@
+const startBtn = document.getElementById('startBtn');
+const createOfferBtn = document.getElementById('createOfferBtn');
+const createAnswerBtn = document.getElementById('createAnswerBtn');
+const applyAnswerBtn = document.getElementById('applyAnswerBtn');
+const offerField = document.getElementById('offer');
+const answerField = document.getElementById('answer');
+const localVideo = document.getElementById('localVideo');
+const remoteVideo = document.getElementById('remoteVideo');
+
+let pc; // RTCPeerConnection
+let localStream;
+
+async function initPeerConnection() {
+  pc = new RTCPeerConnection({
+    iceServers: [{ urls: 'stun:stun.l.google.com:19302' }]
+  });
+
+  pc.onicecandidate = (event) => {
+    if (event.candidate) return;
+    const desc = pc.localDescription;
+    if (!desc) return;
+    if (desc.type === 'offer') {
+      offerField.value = JSON.stringify(desc);
+    } else if (desc.type === 'answer') {
+      answerField.value = JSON.stringify(desc);
+    }
+  };
+
+  pc.ontrack = (event) => {
+    remoteVideo.srcObject = event.streams[0];
+  };
+
+  if (localStream) {
+    localStream.getTracks().forEach((track) => pc.addTrack(track, localStream));
+  }
+}
+
+startBtn.onclick = async () => {
+  localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+  localVideo.srcObject = localStream;
+  createOfferBtn.disabled = false;
+};
+
+createOfferBtn.onclick = async () => {
+  await initPeerConnection();
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  // icecandidate handler will set the textarea
+};
+
+createAnswerBtn.onclick = async () => {
+  await initPeerConnection();
+  const offer = JSON.parse(offerField.value);
+  await pc.setRemoteDescription(offer);
+  const answer = await pc.createAnswer();
+  await pc.setLocalDescription(answer);
+  // icecandidate handler will set the textarea
+};
+
+applyAnswerBtn.onclick = async () => {
+  const answer = JSON.parse(answerField.value);
+  await pc.setRemoteDescription(answer);
+};


### PR DESCRIPTION
## Summary
- add simple WebRTC demo page with manual offer/answer exchange
- document steps for using the demo

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68938b873cb48320a0fc0fe1f4ae6812